### PR TITLE
Only annotate

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -34,8 +34,7 @@ params {
     hmmextend = false
     blastextend = false
     chromomap = false
-
-    only_annotate = ''
+    onlyannotate = false
 
     sankey = 25
     chunk = 10

--- a/nextflow.config
+++ b/nextflow.config
@@ -35,12 +35,15 @@ params {
     blastextend = false
     chromomap = false
 
+    only_annotate = ''
+
     sankey = 25
     chunk = 10
     length = 1.5 // in kb, so 0.5 filters all contigs shorter 500 nt
 
     // development
-    version = 'v3'
+    viphog_version = 'v3'
+    meta_version = 'v1'
 
     // folder structure
     output = 'results'

--- a/nextflow/modules/ratio_evalue.nf
+++ b/nextflow/modules/ratio_evalue.nf
@@ -29,24 +29,27 @@ out PRJNA530103_small_modified_informative.tsv
 process metaGetDB {
   label 'ratio_evalue'    
   if (params.cloudProcess) { 
-    publishDir "${params.cloudDatabase}/models", mode: 'copy', pattern: "Additional_data_vpHMMs.dict" 
+    publishDir "${params.cloudDatabase}/models", mode: 'copy', pattern: "Additional_data_vpHMMs_${params.meta_version}.dict" 
   }
   else { 
     storeDir "nextflow-autodownload-databases/models" 
   }  
     
     output:
-      file("Additional_data_vpHMMs.dict")
+      file("Additional_data_vpHMMs_${params.meta_version}.dict")
     
     shell:
+    if (params.meta_version.toString() == 'v1')
     """
-    # v2 of metadata file
-#    wget ftp://ftp.ebi.ac.uk/pub/databases/metagenomics/viral-pipeline/Additional_data_vpHMMs_v2.xlsx
-#    generate_vphmm_object.py -x Additional_data_vpHMMs_v2.xlsx -o Additional_data_vpHMMs.dict
-
     # v1 of metadata file
     wget ftp://ftp.ebi.ac.uk/pub/databases/metagenomics/viral-pipeline/Additional_data_vpHMMs.xlsx
-    generate_vphmm_object.py -x Additional_data_vpHMMs.xlsx -o Additional_data_vpHMMs.dict
+    generate_vphmm_object.py -x Additional_data_vpHMMs.xlsx -o Additional_data_vpHMMs_${params.meta_version}.dict
     """
+    else if (params.meta_version.toString() == 'v2')
+    """
+    # v2 of metadata file
+    wget ftp://ftp.ebi.ac.uk/pub/databases/metagenomics/viral-pipeline/Additional_data_vpHMMs_v2.xlsx
+    generate_vphmm_object.py -x Additional_data_vpHMMs_v2.xlsx -o Additional_data_vpHMMs_${params.meta_version}.dict
+    """
+    
 }
-

--- a/nextflow/modules/restore.nf
+++ b/nextflow/modules/restore.nf
@@ -4,7 +4,7 @@ process restore {
       label 'python3'
 
     input:
-      tuple val(name), file(fasta), file(virsorter_meta), file(viruses_log), file(assembly), file(map) 
+      tuple val(name), file(fasta), file(map) 
     
     output:
       tuple val(name), env(BN), file("*_original.fasta")

--- a/nextflow/modules/viphogGetDB.nf
+++ b/nextflow/modules/viphogGetDB.nf
@@ -1,19 +1,19 @@
 process viphogGetDB {
   label 'noDocker'    
   if (params.cloudProcess) { 
-    publishDir "${params.cloudDatabase}/", mode: 'copy', pattern: "vpHMM_database_${params.version}" 
+    publishDir "${params.cloudDatabase}/", mode: 'copy', pattern: "vpHMM_database_${params.viphog_version}" 
   }
   else { 
     storeDir "nextflow-autodownload-databases/" 
   }  
 
   output:
-    file("vpHMM_database_${params.version}")
+    file("vpHMM_database_${params.viphog_version}")
 
   script:
     """
-    wget -nH ftp://ftp.ebi.ac.uk/pub/databases/metagenomics/viral-pipeline/hmmer_databases/vpHMM_database_${params.version}.tar.gz && tar -zxvf vpHMM_database_${params.version}.tar.gz
-    rm vpHMM_database_${params.version}.tar.gz
+    wget -nH ftp://ftp.ebi.ac.uk/pub/databases/metagenomics/viral-pipeline/hmmer_databases/vpHMM_database_${params.viphog_version}.tar.gz && tar -zxvf vpHMM_database_${params.viphog_version}.tar.gz
+    rm vpHMM_database_${params.viphog_version}.tar.gz
     """
 }
 

--- a/nextflow/modules/virsorter.nf
+++ b/nextflow/modules/virsorter.nf
@@ -13,13 +13,13 @@ process virsorter {
       tuple val(name), file("*")
     
     script:
+      if (params.virome)
       """
-      #perl /usr/local/bin/wrapper_phage_contigs_sorter_iPlant.pl -f ${fasta} --db 2 --wdir virsorter --ncpu ${task.cpus} --data-dir ${database}
-      if [[ "${params.virome}" == "true" ]]; then 
-        wrapper_phage_contigs_sorter_iPlant.pl -f ${fasta} --db 2 --wdir virsorter --ncpu ${task.cpus} --data-dir ${database} --virome
+      wrapper_phage_contigs_sorter_iPlant.pl -f ${fasta} --db 2 --wdir virsorter --ncpu ${task.cpus} --data-dir ${database} --virome
+      """
       else
-        wrapper_phage_contigs_sorter_iPlant.pl -f ${fasta} --db 2 --wdir virsorter --ncpu ${task.cpus} --data-dir ${database}
-      fi
+      """
+      wrapper_phage_contigs_sorter_iPlant.pl -f ${fasta} --db 2 --wdir virsorter --ncpu ${task.cpus} --data-dir ${database}
       """
 }
 

--- a/virify.nf
+++ b/virify.nf
@@ -34,6 +34,8 @@ if (workflow.profile == 'standard') {
 println "\033[2mDev ViPhOG database: $params.viphog_version\u001B[0m"
 println "\033[2mDev Meta database: $params.meta_version\u001B[0m"
 println " "
+println "\033[2mOnly run annotation: $params.onlyannotate\u001B[0m"
+println " "
         
 if( !nextflow.version.matches('20.01+') ) {
     println "This workflow requires Nextflow version 20.01 or greater -- You are running version $nextflow.version"
@@ -338,7 +340,7 @@ workflow detect {
         parse(length_filtered_ch.join(virfinder.out).join(virsorter.out).join(pprmeta.out))
 
     emit:
-        parse.out.join(renamed_ch).transpose().map{name, fasta, vs_meta, log, renamed_fasta, map -> tuple (name, fasta, map)}.view()
+        parse.out.join(renamed_ch).transpose().map{name, fasta, vs_meta, log, renamed_fasta, map -> tuple (name, fasta, map)}
 }
 
 
@@ -503,7 +505,7 @@ workflow {
     // only detection based on an assembly
     if (params.fasta) {
       // only annotate the FASTA
-      if (params.only_annotate) {
+      if (params.onlyannotate) {
         plot(
           annotate(
             postprocess(preprocess(fasta_input_ch).map{name, renamed_fasta, map, filtered_fasta, contig_number -> tuple(name, filtered_fasta, map)}), viphog_db, ncbi_db, rvdb_db, pvogs_db, vogdb_db, vpf_db, imgvr_db, additional_model_data)
@@ -580,7 +582,7 @@ def helpMSG() {
     --length            Initial length filter in kb [default: $params.length]
     --sankey            select the x taxa with highest count for sankey plot, try and error to change plot [default: $params.sankey]
     --chunk             WIP: chunk FASTA files into smaller pieces for parallel calculation [default: $params.chunk]
-    --only-annotate     Only annotate the input FASTA (no virus prediction, only contig length filtering) [default: $params.only_annotate]
+    --onlyannotate      Only annotate the input FASTA (no virus prediction, only contig length filtering) [default: $params.only_annotate]
 
     ${c_yellow}Developing:${c_reset}
     --viphog_version    define the ViPhOG db version to be used [default: $params.viphog_version]


### PR DESCRIPTION
I want to run the nextflow w/o the virus detection part. Let's say I have a FASTA with viruses sequences that I just want to annotate and not filter for putative virus signals. 

This is now implemented in the nextflow via the flag

```
--onlyannotate
```

If the flag is set, the detection sub-workflow will be skipped. Renaming and Length filtering will be still applied. 

I also added `--viphog_version` and `--meta_version` because Guillermo and I are currently testing the different model versions we have. With the flags, I can more easily switch between the different tables (this is more a development thing)

I thought you might be interested in the changes, so please have a look, and if you are fine please feel free to merge this into master. 
