### PR TITLE
Bugfix toil empty directory vsorter

### DIFF
--- a/bin/parse_viral_pred.py
+++ b/bin/parse_viral_pred.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import argparse
-import glob
 import re
 import sys
 import csv
@@ -108,7 +107,7 @@ def _parse_virsorter_metadata(name):
     return clean_name, "circular" in name, prange
 
 
-def parse_virus_sorter(folder_name):
+def parse_virus_sorter(sorter_files):
     """Extract high, low and prophages confidence Records from virus sorter results.
     High confidence are contigs in the categories 1 and 2
     Low confidence are contigs in the category 3
@@ -119,9 +118,9 @@ def parse_virus_sorter(folder_name):
     low_confidence = dict()
     prophages = dict()
 
-    files = glob.glob(join(folder_name, '*cat-[1,2,3,4,5].fasta'))
-
-    for file in files:
+    for file in sorter_files:
+        if ".fasta" not in file:
+            continue
         for record in SeqIO.parse(file, "fasta"):
             category = record.id[-1:]
             clean_name, circular, prange = _parse_virsorter_metadata(record.id)
@@ -243,8 +242,8 @@ if __name__ == "__main__":
     parser.add_argument("-f", "--vfout", dest="finder", help="Absolute or "
                         "relative path to VirFinder output file",
                         required=True)
-    parser.add_argument("-s", "--vsdir", dest="sorter",
-                        help="Absolute or relative path to directory containing"
+    parser.add_argument("-s", "--vsfiles", dest="sorter", nargs='+',
+                        help="VirSorter .fasta files (i.e. VIRSorter_cat-1.fasta)"
                         " VirSorter output", required=True)
     parser.add_argument("-p", "--pmout", dest="pprmeta",
                         help="Absolute or relative path to PPR-Meta output file"
@@ -256,4 +255,3 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     main(args.pprmeta, args.finder, args.sorter, args.assembly, args.outdir)
-

--- a/cwl/src/Tools/Annotation/viral_annotation.cwl
+++ b/cwl/src/Tools/Annotation/viral_annotation.cwl
@@ -40,7 +40,7 @@ $namespaces:
  s: http://schema.org/
 $schemas:
  - http://edamontology.org/EDAM_1.16.owl
- - https://schema.org/docs/schemaorg.owl
+ - https://schema.org/version/latest/schema.rdf
 
 s:license: "https://www.apache.org/licenses/LICENSE-2.0"
 s:copyrightHolder:

--- a/cwl/src/Tools/Annotation/viral_annotation_swf.cwl
+++ b/cwl/src/Tools/Annotation/viral_annotation_swf.cwl
@@ -44,7 +44,7 @@ $namespaces:
  s: http://schema.org/
 $schemas:
  - http://edamontology.org/EDAM_1.16.owl
- - https://schema.org/docs/schemaorg.owl
+ - https://schema.org/version/latest/schema.rdf
 
 s:license: "https://www.apache.org/licenses/LICENSE-2.0"
 s:copyrightHolder:

--- a/cwl/src/Tools/Assign/assign.cwl
+++ b/cwl/src/Tools/Assign/assign.cwl
@@ -43,7 +43,7 @@ $namespaces:
  s: http://schema.org/
 $schemas:
  - http://edamontology.org/EDAM_1.16.owl
- - https://schema.org/docs/schemaorg.owl
+ - https://schema.org/version/latest/schema.rdf
 
 s:license: "https://www.apache.org/licenses/LICENSE-2.0"
 

--- a/cwl/src/Tools/Assign/assign_swf.cwl
+++ b/cwl/src/Tools/Assign/assign_swf.cwl
@@ -38,7 +38,7 @@ $namespaces:
  s: http://schema.org/
 $schemas:
  - http://edamontology.org/EDAM_1.16.owl
- - https://schema.org/docs/schemaorg.owl
+ - https://schema.org/version/latest/schema.rdf
 
 s:license: "https://www.apache.org/licenses/LICENSE-2.0"
 s:copyrightHolder:

--- a/cwl/src/Tools/FastaRename/fasta_rename.cwl
+++ b/cwl/src/Tools/FastaRename/fasta_rename.cwl
@@ -63,7 +63,7 @@ $namespaces:
  s: http://schema.org/
 $schemas:
  - http://edamontology.org/EDAM_1.16.owl
- - https://schema.org/docs/schemaorg.owl
+ - https://schema.org/version/latest/schema.rdf
 
 s:license: "https://www.apache.org/licenses/LICENSE-2.0"
 s:copyrightHolder:

--- a/cwl/src/Tools/FastaRename/fasta_restore.cwl
+++ b/cwl/src/Tools/FastaRename/fasta_restore.cwl
@@ -61,7 +61,7 @@ $namespaces:
  s: http://schema.org/
 $schemas:
  - http://edamontology.org/EDAM_1.16.owl
- - https://schema.org/docs/schemaorg.owl
+ - https://schema.org/version/latest/schema.rdf
 
 s:license: "https://www.apache.org/licenses/LICENSE-2.0"
 s:copyrightHolder:

--- a/cwl/src/Tools/HMMScan/hmmscan.cwl
+++ b/cwl/src/Tools/HMMScan/hmmscan.cwl
@@ -50,7 +50,7 @@ $namespaces:
  s: http://schema.org/
 $schemas:
  - http://edamontology.org/EDAM_1.16.owl
- - https://schema.org/docs/schemaorg.owl
+ - https://schema.org/version/latest/schema.rdf
 
 s:license: "https://www.apache.org/licenses/LICENSE-2.0"
 s:copyrightHolder:

--- a/cwl/src/Tools/HMMScan/hmmscan_format_table.cwl
+++ b/cwl/src/Tools/HMMScan/hmmscan_format_table.cwl
@@ -38,7 +38,7 @@ $namespaces:
  s: http://schema.org/
 $schemas:
  - http://edamontology.org/EDAM_1.16.owl
- - https://schema.org/docs/schemaorg.owl
+ - https://schema.org/version/latest/schema.rdf
 
 s:license: "https://www.apache.org/licenses/LICENSE-2.0"
 s:copyrightHolder:

--- a/cwl/src/Tools/HMMScan/hmmscan_swf.cwl
+++ b/cwl/src/Tools/HMMScan/hmmscan_swf.cwl
@@ -60,7 +60,7 @@ $namespaces:
  s: http://schema.org/
 $schemas:
  - http://edamontology.org/EDAM_1.16.owl
- - https://schema.org/docs/schemaorg.owl
+ - https://schema.org/version/latest/schema.rdf
 
 s:license: "https://www.apache.org/licenses/LICENSE-2.0"
 s:copyrightHolder:

--- a/cwl/src/Tools/IMGvrBlast/imgvr_blast.cwl
+++ b/cwl/src/Tools/IMGvrBlast/imgvr_blast.cwl
@@ -52,7 +52,7 @@ $namespaces:
  s: http://schema.org/
  edam: http://edamontology.org/
 $schemas:
- - https://schema.org/docs/schemaorg.owl
+ - https://schema.org/version/latest/schema.rdf
 
 s:license: "https://www.apache.org/licenses/LICENSE-2.0"
 s:copyrightHolder:

--- a/cwl/src/Tools/IMGvrBlast/imgvr_blast_swf.cwl
+++ b/cwl/src/Tools/IMGvrBlast/imgvr_blast_swf.cwl
@@ -62,7 +62,7 @@ $namespaces:
  s: http://schema.org/
 $schemas:
  - http://edamontology.org/EDAM_1.16.owl
- - https://schema.org/docs/schemaorg.owl
+ - https://schema.org/version/latest/schema.rdf
 
 s:license: "https://www.apache.org/licenses/LICENSE-2.0"
 s:copyrightHolder:

--- a/cwl/src/Tools/IMGvrBlast/imgvr_merge.cwl
+++ b/cwl/src/Tools/IMGvrBlast/imgvr_merge.cwl
@@ -42,7 +42,7 @@ $namespaces:
  s: http://schema.org/
  edam: http://edamontology.org/
 $schemas:
- - https://schema.org/docs/schemaorg.owl
+ - https://schema.org/version/latest/schema.rdf
 
 s:license: "https://www.apache.org/licenses/LICENSE-2.0"
 s:copyrightHolder:

--- a/cwl/src/Tools/Krona/generate_counts_table.cwl
+++ b/cwl/src/Tools/Krona/generate_counts_table.cwl
@@ -33,7 +33,7 @@ $namespaces:
  s: http://schema.org/
  edam: http://edamontology.org/
 $schemas:
- - https://schema.org/docs/schemaorg.owl
+ - https://schema.org/version/latest/schema.rdf
 
 s:license: "https://www.apache.org/licenses/LICENSE-2.0"
 s:copyrightHolder:

--- a/cwl/src/Tools/Krona/krona.cwl
+++ b/cwl/src/Tools/Krona/krona.cwl
@@ -38,7 +38,7 @@ $namespaces:
  s: http://schema.org/
 $schemas:
  - http://edamontology.org/EDAM_1.16.owl
- - https://schema.org/docs/schemaorg.owl
+ - https://schema.org/version/latest/schema.rdf
 
 s:license: "https://www.apache.org/licenses/LICENSE-2.0"
 s:copyrightHolder:

--- a/cwl/src/Tools/Krona/krona_swf.cwl
+++ b/cwl/src/Tools/Krona/krona_swf.cwl
@@ -69,7 +69,7 @@ $namespaces:
  s: http://schema.org/
  edam: http://edamontology.org/
 $schemas:
- - https://schema.org/docs/schemaorg.owl
+ - https://schema.org/version/latest/schema.rdf
 
 s:license: "https://www.apache.org/licenses/LICENSE-2.0"
 s:copyrightHolder:

--- a/cwl/src/Tools/LengthFiltering/length_filtering.cwl
+++ b/cwl/src/Tools/LengthFiltering/length_filtering.cwl
@@ -61,7 +61,7 @@ $namespaces:
  s: http://schema.org/
  edam: http://edamontology.org/
 $schemas:
- - https://schema.org/docs/schemaorg.owl
+ - https://schema.org/version/latest/schema.rdf
 
 s:license: "https://www.apache.org/licenses/LICENSE-2.0"
 s:copyrightHolder:

--- a/cwl/src/Tools/MashMap/mashmap.cwl
+++ b/cwl/src/Tools/MashMap/mashmap.cwl
@@ -132,7 +132,7 @@ $namespaces:
  s: http://schema.org/
  edam: http://edamontology.org/
 $schemas:
- - https://schema.org/docs/schemaorg.owl
+ - https://schema.org/version/latest/schema.rdf
 
 s:license: "https://www.apache.org/licenses/LICENSE-2.0"
 s:copyrightHolder:

--- a/cwl/src/Tools/MashMap/mashmap_swf.cwl
+++ b/cwl/src/Tools/MashMap/mashmap_swf.cwl
@@ -50,7 +50,7 @@ $namespaces:
  s: http://schema.org/
  edam: http://edamontology.org/
 $schemas:
- - https://schema.org/docs/schemaorg.owl
+ - https://schema.org/version/latest/schema.rdf
 
 s:license: "https://www.apache.org/licenses/LICENSE-2.0"
 s:copyrightHolder:

--- a/cwl/src/Tools/PPRMeta/pprmeta.cwl
+++ b/cwl/src/Tools/PPRMeta/pprmeta.cwl
@@ -38,7 +38,7 @@ $namespaces:
  s: http://schema.org/
 $schemas:
  - http://edamontology.org/EDAM_1.16.owl
- - https://schema.org/docs/schemaorg.owl
+ - https://schema.org/version/latest/schema.rdf
 
 s:license: "https://www.apache.org/licenses/LICENSE-2.0"
 s:copyrightHolder:

--- a/cwl/src/Tools/ParsingPredictions/parse_viral_pred.cwl
+++ b/cwl/src/Tools/ParsingPredictions/parse_viral_pred.cwl
@@ -26,8 +26,9 @@ inputs:
     inputBinding:
       separate: true
       prefix: "-f"
-  virsorter_dir:
-    type: Directory
+  virsorter_fastas:
+    type: File[]
+    format: edam:format_1929
     inputBinding:
       separate: true
       prefix: "-s"
@@ -87,7 +88,7 @@ $namespaces:
  s: http://schema.org/
  edam: http://edamontology.org/
 $schemas:
- - https://schema.org/docs/schemaorg.owl
+ - https://schema.org/version/latest/schema.rdf
 
 s:license: "https://www.apache.org/licenses/LICENSE-2.0"
 s:copyrightHolder:

--- a/cwl/src/Tools/Prodigal/prodigal.cwl
+++ b/cwl/src/Tools/Prodigal/prodigal.cwl
@@ -55,7 +55,7 @@ $namespaces:
  s: http://schema.org/
  edam: http://edamontology.org/
 $schemas:
- - https://schema.org/docs/schemaorg.owl
+ - https://schema.org/version/latest/schema.rdf
 
 s:license: "https://www.apache.org/licenses/LICENSE-2.0"
 s:copyrightHolder:

--- a/cwl/src/Tools/Prodigal/prodigal_swf.cwl
+++ b/cwl/src/Tools/Prodigal/prodigal_swf.cwl
@@ -60,7 +60,7 @@ $namespaces:
  s: http://schema.org/
  edam: http://edamontology.org/
 $schemas:
- - https://schema.org/docs/schemaorg.owl
+ - https://schema.org/version/latest/schema.rdf
 
 s:license: "https://www.apache.org/licenses/LICENSE-2.0"
 s:copyrightHolder:

--- a/cwl/src/Tools/RatioEvalue/ratio_evalue.cwl
+++ b/cwl/src/Tools/RatioEvalue/ratio_evalue.cwl
@@ -46,7 +46,7 @@ $namespaces:
  s: http://schema.org/
  edam: http://edamontology.org/
 $schemas:
- - https://schema.org/docs/schemaorg.owl
+ - https://schema.org/version/latest/schema.rdf
 
 s:license: "https://www.apache.org/licenses/LICENSE-2.0"
 s:copyrightHolder:

--- a/cwl/src/Tools/Utils/concatenate.cwl
+++ b/cwl/src/Tools/Utils/concatenate.cwl
@@ -32,7 +32,7 @@ outputs:
 $namespaces:
  s: http://schema.org/
 $schemas:
- - https://schema.org/docs/schemaorg.owl
+ - https://schema.org/version/latest/schema.rdf
 
 s:license: "https://www.apache.org/licenses/LICENSE-2.0"
 s:copyrightHolder:

--- a/cwl/src/Tools/VirFinder/virfinder.cwl
+++ b/cwl/src/Tools/VirFinder/virfinder.cwl
@@ -44,7 +44,7 @@ $namespaces:
  s: http://schema.org/
  edam: http://edamontology.org/
 $schemas:
- - https://schema.org/docs/schemaorg.owl
+ - https://schema.org/version/latest/schema.rdf
 
 s:license: "https://www.apache.org/licenses/LICENSE-2.0"
 s:copyrightHolder:

--- a/cwl/src/Tools/VirSorter/virsorter.cwl
+++ b/cwl/src/Tools/VirSorter/virsorter.cwl
@@ -80,12 +80,17 @@ stderr: stderr.txt
 outputs:
   stdout: stdout
   stderr: stderr
-  predicted_viral_seq_dir:
-     type: Directory
+
+  virsorter_fastas:
+     type: File[]
+     format: edam:format_1929
      outputBinding:
-        glob: virsorter-out/Predicted_viral_sequences/
-        outputEval: |
-          ${ self[0].basename = "predicted_viral_sequences"; return self; }
+        glob: virsorter-out/Predicted_viral_sequences/*.fasta
+
+  virsorter_genebanks:
+     type: File[]
+     outputBinding:
+        glob: virsorter-out/Predicted_viral_sequences/*.gb
 doc: |
   usage: wrapper_phage_contigs_sorter_iPlant.pl --fasta sequences.fa
 
@@ -124,7 +129,7 @@ $namespaces:
  s: http://schema.org/
  edam: http://edamontology.org/
 $schemas:
- - https://schema.org/docs/schemaorg.owl
+ - https://schema.org/version/latest/schema.rdf
 
 s:license: "https://www.apache.org/licenses/LICENSE-2.0"
 s:copyrightHolder:

--- a/cwl/src/pipeline.cwl
+++ b/cwl/src/pipeline.cwl
@@ -94,7 +94,7 @@ steps:
       data_dir: virsorter_data_dir
       virome_decontamination_mode: virsorter_virome
     out:
-      - predicted_viral_seq_dir
+      - virsorter_fastas 
 
   pprmeta:
     label: PPR-Meta
@@ -111,7 +111,7 @@ steps:
     in:
       assembly: length_filter/filtered_contigs_fasta
       virfinder_tsv: virfinder/virfinder_output
-      virsorter_dir: virsorter/predicted_viral_seq_dir
+      virsorter_fastas: virsorter/virsorter_fastas
       pprmeta_csv: pprmeta/pprmeta_output
     out:
       - high_confidence_contigs
@@ -252,9 +252,9 @@ outputs:
   virfinder_output:
     outputSource: virfinder/virfinder_output
     type: File
-  virsorter_output:
-    outputSource: virsorter/predicted_viral_seq_dir
-    type: Directory
+  virsorter_output_fastas:
+    outputSource: virsorter/virsorter_fastas
+    type: File[]
   high_confidence_contigs:
     outputSource: fasta_restore_name_hc/restored_fasta
     type: File?
@@ -308,7 +308,7 @@ $namespaces:
  s: http://schema.org/
 $schemas:
  - http://edamontology.org/EDAM_1.16.owl
- - https://schema.org/docs/schemaorg.owl
+ - https://schema.org/version/latest/schema.rdf
 
 s:license: "https://www.apache.org/licenses/LICENSE-2.0"
 s:copyrightHolder:

--- a/cwl/tests/tests.yml
+++ b/cwl/tests/tests.yml
@@ -194,98 +194,94 @@
   short_name: virsorter.cwl
   doc: VirSorter
   output:
-      predicted_viral_seq_dir:
-        basename: predicted_viral_sequences
-        class: Directory
+    virsorter_fastas:
+      - class: File
+        basename: VIRSorter_cat-1.fasta
+        checksum: Any
         location: Any
+        path: Any  
+        size: 5448
+      - class: File
+        basename: VIRSorter_cat-2.fasta
+        checksum: Any
+        size: 37434
+        location: Any
+        path: Any    
+      - class: File
+        basename: VIRSorter_cat-3.fasta
+        checksum: sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709
+        size: 0
+        location: Any
+        path: Any    
+      - class: File
+        basename: VIRSorter_prophages_cat-4.fasta
+        checksum: Any
+        size: 0
+        location: Any
+        path: Any    
+      - class: File
+        basename: VIRSorter_prophages_cat-5.fasta
+        checksum: Any
+        size: 0
+        location: Any
+        path: Any    
+      - class: File
+        basename: VIRSorter_prophages_cat-6.fasta
+        checksum: sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709
+        size: 0
         path: Any
-        listing: &virsorter
-          - class: File
-            basename: VIRSorter_cat-1.fasta
-            checksum: Any
-            location: Any
-            path: Any  
-            size: 5448
-          - class: File
-            basename: VIRSorter_cat-2.fasta
-            checksum: Any
-            size: 37434
-            location: Any
-            path: Any    
-          - class: File
-            basename: VIRSorter_cat-3.fasta
-            checksum: sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709
-            size: 0
-            location: Any
-            path: Any    
-          - class: File
-            basename: VIRSorter_prophages_cat-4.fasta
-            checksum: Any
-            size: 0
-            location: Any
-            path: Any    
-          - class: File
-            basename: VIRSorter_prophages_cat-5.fasta
-            checksum: Any
-            size: 0
-            location: Any
-            path: Any    
-          - class: File
-            basename: VIRSorter_prophages_cat-6.fasta
-            checksum: sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709
-            size: 0
-            path: Any
-            location: Any
-          - class: File
-            basename: VIRSorter_cat-1.gb
-            checksum: Any
-            size: 13292
-            location: Any
-            path: Any    
-          - class: File
-            basename: VIRSorter_cat-2.gb
-            checksum: Any
-            location: Any
-            path: Any
-            size: 87306
-          - class: File
-            basename: VIRSorter_cat-3.gb
-            checksum: sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709
-            size: 0
-            location: Any
-            path: Any
-          - class: File
-            basename: VIRSorter_prophages_cat-4.gb
-            location: Any
-            path: Any
-            checksum: sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709
-            size: 0
-          - class: File
-            basename: VIRSorter_prophages_cat-5.gb
-            checksum: sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709
-            size: 0
-            location: Any
-            path: Any    
-          - class: File
-            basename: VIRSorter_prophages_cat-6.gb
-            checksum: sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709
-            size: 0
-            location: Any
-            path: Any    
-      stderr:
-        class: File
-        basename: stderr.txt
+        location: Any
+    virsorter_genebanks:
+      - class: File
+        basename: VIRSorter_cat-1.gb
+        checksum: Any
+        size: 13292
+        location: Any
+        path: Any    
+      - class: File
+        basename: VIRSorter_cat-2.gb
         checksum: Any
         location: Any
         path: Any
-        size: Any
-      stdout:
-        class: File
-        basename: stdout.txt
-        checksum: Any
+        size: 87306
+      - class: File
+        basename: VIRSorter_cat-3.gb
+        checksum: sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709
+        size: 0
         location: Any
         path: Any
-        size: Any
+      - class: File
+        basename: VIRSorter_prophages_cat-4.gb
+        location: Any
+        path: Any
+        checksum: sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709
+        size: 0
+      - class: File
+        basename: VIRSorter_prophages_cat-5.gb
+        checksum: sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709
+        size: 0
+        location: Any
+        path: Any    
+      - class: File
+        basename: VIRSorter_prophages_cat-6.gb
+        checksum: sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709
+        size: 0
+        location: Any
+        path: Any
+    stderr:
+      class: File
+      basename: stderr.txt
+      checksum: Any
+      location: Any
+      path: Any
+      size: Any
+    stdout:
+      class: File
+      basename: stdout.txt
+      checksum: Any
+      location: Any
+      path: Any
+      size: Any
 
 # Krona
 - job: tools/krona/krona_test_input.yml

--- a/cwl/tests/tools/parse/parse_test_input.yml
+++ b/cwl/tests/tools/parse/parse_test_input.yml
@@ -6,10 +6,26 @@ virfinder_tsv:
   class: File
   path: virfinder_output.tsv
   format: http://edamontology.org/format_3475 
-virsorter_dir:
-  class: Directory
-  path: virsorter_results
 pprmeta_csv:
   class: File
   path: pprmeta_out.csv
-  format: http://edamontology.org/format_3752 
+  format: http://edamontology.org/format_3752
+virsorter_fastas:
+  - class: File
+    path: virsorter_results/VIRSorter_cat-1.fasta
+    format: http://edamontology.org/format_1929
+  - class: File
+    path: virsorter_results/VIRSorter_cat-2.fasta
+    format: http://edamontology.org/format_1929
+  - class: File
+    path: virsorter_results/VIRSorter_cat-3.fasta
+    format: http://edamontology.org/format_1929
+  - class: File
+    path: virsorter_results/VIRSorter_prophages_cat-4.fasta
+    format: http://edamontology.org/format_1929
+  - class: File
+    path: virsorter_results/VIRSorter_prophages_cat-5.fasta
+    format: http://edamontology.org/format_1929
+  - class: File
+    path: virsorter_results/VIRSorter_prophages_cat-6.fasta
+    format: http://edamontology.org/format_1929

--- a/cwl/virify.sh
+++ b/cwl/virify.sh
@@ -126,7 +126,7 @@ while getopts "e:n:j:o:c:m:i:vs:r:lh" opt; do
             usage;
             exit 1
         fi
-        MASHMAP_REFERENCE="-m ${OPTARG}" 
+        MASHMAP_REFERENCE="${OPTARG}" 
         ;;
     h)
         usage;
@@ -221,7 +221,7 @@ then
 
     if [ ! -z "${MASHMAP_REFERENCE}" ];
     then
-        CWL_PARAMS+=("${MASHMAP_REFERENCE}")
+        CWL_PARAMS+=(-m "${MASHMAP_REFERENCE}")
     fi
 
     if [ ! -z "${VIROME}" ];

--- a/nextflow/modules/parse.nf
+++ b/nextflow/modules/parse.nf
@@ -17,7 +17,7 @@ process parse {
     script:
     """
     touch virsorter_metadata.tsv
-    parse_viral_pred.py -a ${fasta} -f ${virfinder} -s ${virsorter}/Predicted_viral_sequences/ -p ${pprmeta} &> ${name}_virus_predictions.log
+    parse_viral_pred.py -a ${fasta} -f ${virfinder} -p ${pprmeta} -s ${virsorter}/Predicted_viral_sequences/*.fasta &> ${name}_virus_predictions.log
     """
 }
 

--- a/tests/test_parse_viral_preds.py
+++ b/tests/test_parse_viral_preds.py
@@ -76,9 +76,10 @@ class ParseViralPredictions(unittest.TestCase):
         """For virsorter => virsorter_finder_test_data/input.fasta the expected is:
         """
         path = self._build_path("/base_fixtures/virsorter/")
-        hc, lc, p = parse_virus_sorter(path)
+        hc, lc, p = parse_virus_sorter([os.path.join(path, f) for f in os.listdir(path)])
 
-        self.assertSetEqual(set([r.seq_id for _, r in hc.items()]), set(["pos_phage_2", "pos_phage_1"]))
+        self.assertSetEqual(set([r.seq_id for _, r in hc.items()]),
+                            set(["pos_phage_2", "pos_phage_1"]))
         self.assertSetEqual(set([r.seq_id for _, r in lc.items()]), set())
         self.assertSetEqual(set([r[0].seq_id for _, r in p.items()]), set(["pos_phage_0"]))
 
@@ -99,7 +100,9 @@ class ParseViralPredictions(unittest.TestCase):
         vs_path = self._build_path("/kleiner2015/predicted_viral_sequences")
         assembly = self._build_path("/kleiner2015/kleiner_2015_renamed.fasta")
 
-        hc, lc, pp, *_ = merge_annotations(pprmeta_path, vf_path, vs_path, assembly)
+        vs_files = [os.path.join(vs_path, f) for f in os.listdir(vs_path)]
+
+        hc, lc, pp, *_ = merge_annotations(pprmeta_path, vf_path, vs_files, assembly)
 
         hc_ids = set([h.id for h in hc])
         lc_ids = set([l.id for l in lc])
@@ -122,7 +125,9 @@ class ParseViralPredictions(unittest.TestCase):
         assembly = self._build_path("/kleiner2015/kleiner_2015_renamed.fasta")
         test_dir = tempfile.mkdtemp()
 
-        main(pprmeta_path, vf_path, vs_path, assembly, test_dir)
+        vs_files = [os.path.join(vs_path, f) for f in os.listdir(vs_path)]
+
+        main(pprmeta_path, vf_path, vs_files, assembly, test_dir)
 
         with open(test_dir + "/high_confidence_putative_viral_contigs.fna", "rb") as hc_f:
             with open(
@@ -167,7 +172,9 @@ class ParseViralPredictions(unittest.TestCase):
 
         test_dir = tempfile.mkdtemp()
 
-        main(pprmeta_path, vf_path, vs_path, assembly, test_dir)
+        sorter_files = [os.path.join(vs_path, f) for f in os.listdir(vs_path)]
+
+        main(pprmeta_path, vf_path, sorter_files, assembly, test_dir)
 
         with open(test_dir + "/high_confidence_putative_viral_contigs.fna", "rb") as hc_f:
             with open(


### PR DESCRIPTION
I had to change the way parse_script was taking VirSorter input files, instead of supplying the directory now the script takes an array of files.

Tested the CWL version on the cluster and works.
Tested the Nextflow version locally and works.

Other changes:
- schema.org RDF links in .cwl
 