### PR TITLE
Metadata file v4, also included a warning about the deleted taxa.

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -48,7 +48,7 @@ params {
 
     // development
     viphog_version = 'v3'
-    meta_version = 'v3'
+    meta_version = 'v4'
 
     // folder structure
     output = 'results'

--- a/nextflow/modules/metaGetDB.nf
+++ b/nextflow/modules/metaGetDB.nf
@@ -12,19 +12,8 @@ process metaGetDB {
       file("additional_data_vpHMMs_${params.meta_version}.tsv")
     
     script:
-    if (params.meta_version.toString() == 'v1')
     """
-    # v1 of metadata file
-    wget ftp://ftp.ebi.ac.uk/pub/databases/metagenomics/viral-pipeline/additional_data_vpHMMs_v1.tsv
-    """
-    else if (params.meta_version.toString() == 'v2')
-    """
-    # v2 of metadata file
-    wget ftp://ftp.ebi.ac.uk/pub/databases/metagenomics/viral-pipeline/additional_data_vpHMMs_v2.tsv
-    """
-    else if (params.meta_version.toString() == 'v3')
-    """
-    # v2 of metadata file
-    wget ftp://ftp.ebi.ac.uk/pub/databases/metagenomics/viral-pipeline/additional_data_vpHMMs_v3.tsv
+    echo "Downloading ${params.meta_version} of the metadata"
+    wget ftp://ftp.ebi.ac.uk/pub/databases/metagenomics/viral-pipeline/additional_data_vpHMMs_${params.meta_version}.tsv
     """
 }

--- a/virify.nf
+++ b/virify.nf
@@ -38,12 +38,14 @@ println "\033[2mDev Meta database: $params.meta_version\u001B[0m"
 println " "
 println "\033[2mOnly run annotation: $params.onlyannotate\u001B[0m"
 println " "
-        
+
 if (params.help) { exit 0, helpMSG() }
 if (params.profile) {
   exit 1, "--profile is WRONG use -profile" }
 if (params.illumina == '' &&  params.fasta == '' ) {
   exit 1, "input missing, use [--illumina] or [--fasta]"}
+
+if (params.meta_version == "v4") { printMetadataV4Warning() }
 
 /************************** 
 * INPUT CHANNELS 
@@ -652,6 +654,34 @@ workflow {
     }
 }
 
+def printMetadataV4Warning() {
+    c_yellow = "\033[0;33m";
+    c_reset = "\033[0m";
+
+    println """
+    ${c_yellow}Warning: --meta_version v4 does not include the following discontinued virus taxa 
+    (according to ICTV) anymore and they have been excluded from the dataset.${c_reset}
+
+    Siphoviridae
+    Podoviridae
+    Myoviridae
+    Caudovirales
+    Allolevivirus
+    Autographivirinae
+    Buttersvirus
+    Chungbukvirus
+    Incheonvirus
+    Leviviridae
+    Levivirus
+    Mandarivirus
+    Pbi1virus
+    Phicbkvirus
+    Radnorvirus
+    Sitaravirus
+    Vidavervirus
+    """.stripIndent()
+}
+
 /*************  
 * --help
 *************/
@@ -725,6 +755,7 @@ def helpMSG() {
                         v1: older version of the meta data table using an outdated NCBI virus taxonomy, for reproducibility 
                         v2: 2020 version of NCBI virus taxonomy
                         v3: 2022 version of NCBI virus taxonomy
+                        v4: 2022 version of NCBI virus taxonomy
 
     ${c_dim}Nextflow options:
     -with-report rep.html    cpu / ram usage (may cause errors)


### PR DESCRIPTION
The warning message looks like:
```
nextflow run virify.nf --meta_version v4 --fasta nextflow/test/assembly.fasta
N E X T F L O W  ~  version 23.04.0
Launching `virify.nf` [sharp_carlsson] DSL2 - revision: 690a9ff68f

Profile: standard

Current User: mbc
Nextflow-version: 23.04.0
Starting time: 01-04-2023 21:09 UTC
Workdir location:
  /home/mbc/projects/emg-viral-pipeline/work
Databases location:
  nextflow-autodownload-databases

CPUs to use: 2
Output dir name: results

Dev ViPhOG database: v3
Dev Meta database: v4

Only run annotation: false

Warning: --meta_version v4 does not include the following discontinued virus taxa
(according to ICTV) anymore and they have been excluded from the dataset.

Siphoviridae
Podoviridae
Myoviridae
Caudovirales
Allolevivirus
Autographivirinae
Buttersvirus
Chungbukvirus
Incheonvirus
Leviviridae
Levivirus
Mandarivirus
Pbi1virus
Phicbkvirus
Radnorvirus
Sitaravirus
Vidavervirus

executor >  local (6)
...
```

This one should fix #104 