### PR TITLE
remove lsf requirement for ebi profile

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -151,10 +151,7 @@ profiles {
   	    params.singularity_cachedir = "/hps/nobackup/rdf/metagenomics/service-team/singularity-cache/"
 
         workDir = params.workdir
-        executor {
-            name = "lsf"
-            queueSize = 200
-        }        
+     
         params.cloudProcess = true
         process.cache = "lenient"
         includeConfig 'nextflow/configs/node.config'


### PR DESCRIPTION
Remove LSF for EBI profile will allow us to run with both ebi,slurm and ebi,lsf options.