### PR TITLE
Prase.nf results are optional.

### DIFF
--- a/bin/parse_viral_pred.py
+++ b/bin/parse_viral_pred.py
@@ -300,7 +300,7 @@ def main(pprmeta, finder, sorter, assembly, outdir, prefix=False):
             " in the analysed metagenomic assembly",
             file=sys.stderr,
         )
-        exit(1)
+        exit(0)
 
 
 if __name__ == "__main__":

--- a/nextflow/modules/parse.nf
+++ b/nextflow/modules/parse.nf
@@ -1,9 +1,8 @@
 process parse {
-      errorStrategy { task.exitStatus = 1 ? 'ignore' :  'terminate' }
-      publishDir "${params.output}/${name}/", mode: 'copy', pattern: "*.fna"
-      publishDir "${params.output}/${name}/", mode: 'copy', pattern: "virsorter_metadata.tsv"
-      publishDir "${params.output}/${name}/${params.finaldir}/", mode: 'copy', pattern: "${name}_virus_predictions.log"
-      label 'python3'
+    publishDir "${params.output}/${name}/", mode: 'copy', pattern: "*.fna"
+    publishDir "${params.output}/${name}/", mode: 'copy', pattern: "virsorter_metadata.tsv"
+    publishDir "${params.output}/${name}/${params.finaldir}/", mode: 'copy', pattern: "${name}_virus_predictions.log"
+    label 'python3'
 
     input:
       tuple val(name), file(fasta), val(contig_number), file(virfinder), file(virsorter), file(pprmeta)
@@ -12,7 +11,7 @@ process parse {
       contig_number.toInteger() > 0 
 
     output:
-      tuple val(name), file("*.fna"), file('virsorter_metadata.tsv'), file("${name}_virus_predictions.log")
+      tuple val(name), file("*.fna"), file('virsorter_metadata.tsv'), file("${name}_virus_predictions.log"), optional: true
     
     script:
     """


### PR DESCRIPTION
This is to prevent the pipeline from "failing" when there are no viral annotations.

With these changes, the pipeline now finishes in the parse.nf step and produces partial results:

```bash
$ ls -l results
total 2511
drwxrwsr-x 2 mbc metagen    4096 Apr 30 19:05 01-viruses
drwxrwsr-x 2 mbc metagen    4096 Apr 30 19:06 08-final
-rw-rw-r-- 1 mbc metagen 1285574 Apr 30 19:00 MGYG000437699_renamed.fasta
-rw-rw-r-- 1 mbc metagen 1285574 Apr 30 19:00 MGYG000437699_renamed_filt1500bp.fasta
-rw-rw-r-- 1 mbc metagen       0 Apr 30 19:06 virsorter_metadata.ts

$ cat results/08-final/MGYG000437699_virus_predictions.log 
Overall, no putative _viral contigs or prophages were detected in the analysed metagenomic assembly
PPR-Meta found 0 low confidence contigs.
Virus Finder found 0 high confidence contigs.
Virus Finder found 0 low confidence contigs.
Contig has an invalid category : 6
Virus Sorter found 0 high confidence contigs.
Virus Sorter found 0 low confidence contigs.
Virus Sorter found 0 putative prophages contigs.
```

The current behaviour is confusing, as nextflow will mark the pipeline as failed even though it's not a "runtime" error, it's just that there are no viral sequences found.