### PR TITLE
Add VirSorter2 process as an alternative to VirSorter

### DIFF
--- a/bin/parse_viral_pred.py
+++ b/bin/parse_viral_pred.py
@@ -186,7 +186,55 @@ def parse_virus_sorter(sorter_files):
     return high_confidence, low_confidence, prophages
 
 
-def merge_annotations(pprmeta, finder, sorter, assembly):
+def parse_virus_sorter2(sorter_files):
+    """Extract high, low and prophages confidence Records from virus sorter results.
+    High confidence are contigs in the categories 1 and 2
+    Low confidence are contigs in the category 3
+    Putative prophages are in categories 4 and 5
+    (which correspond to VirSorter confidence categories 1 and 2)
+    """
+    high_confidence = dict()
+    low_confidence = dict()
+    prophages = dict()
+
+    if not sorter_files:
+        print('WARNING: no result files from Virus Sorter 2 were found, skipping now.')
+    else:
+        boundary_df = pd.read_csv([filename for filename in sorter_files if 'boundary' in filename][0], sep='\t', index_col = 'seqname_new')
+        score_df = pd.read_csv([filename for filename in sorter_files if 'score' in filename][0], sep='\t', index_col = 'seqname')
+        meta = score_df.merge(boundary_df, left_index=True, right_index=True, how='left', suffixes = ('_score', '_boundary'))
+
+        for record in SeqIO.parse([filename for filename in sorter_files if 'combined' in filename][0], "fasta"):
+
+            max_score = meta.loc[record.id, 'max_score']
+            clean_name = record.id.split('|')[0]
+            circular =  meta.loc[record.id, 'shape'].startswith('c')
+            prange = [meta.loc[record.id, 'trim_bp_start'], meta.loc[record.id, 'trim_bp_end']]
+            
+            if 'partial' in record.id:
+                # add the prophage position within the contig
+                prophages.setdefault(clean_name, []).append(
+                    Record(record, "prophage", circular, prange)
+                )
+            
+            record.id = clean_name
+
+            if float(max_score) >= float(args.vs_cutoff):
+                high_confidence[record.id] = Record(record, "high_confidence", circular)
+            else:
+                low_confidence[record.id] = Record(record, "low_confidence", circular)
+
+
+
+
+    print(f"Virus Sorter found {len(high_confidence)} high confidence contigs.")
+    print(f"Virus Sorter found {len(low_confidence)} low confidence contigs.")
+    print(f"Virus Sorter found {len(prophages)} putative prophages contigs.")
+
+    return high_confidence, low_confidence, prophages
+
+
+def merge_annotations(pprmeta, finder, sorter, sorter2, assembly):
     """Parse VirSorter, VirFinder and PPR-Meta outputs and merge the results.
     High confidence viral contigs:
     -  VirSorter reported as categories 1 and 2
@@ -206,7 +254,7 @@ def merge_annotations(pprmeta, finder, sorter, assembly):
 
     pprmeta_lc = parse_pprmeta(pprmeta)
     finder_lc, finder_lowestc = parse_virus_finder(finder)
-    sorter_hc, sorter_lc, sorter_prophages = parse_virus_sorter(sorter)
+    sorter_hc, sorter_lc, sorter_prophages = parse_virus_sorter(sorter) if sorter is not None else parse_virus_sorter2(sorter2)
 
     for seq_record in SeqIO.parse(assembly, "fasta"):
         # HC
@@ -237,7 +285,7 @@ def merge_annotations(pprmeta, finder, sorter, assembly):
     )
 
 
-def main(pprmeta, finder, sorter, assembly, outdir, prefix=False):
+def main(pprmeta, finder, sorter, sorter2, assembly, outdir, vs_cutoff, prefix=False):
     """Parse VirSorter, VirFinder and PPR-Meta outputs and merge the results."""
     (
         hc_contigs,
@@ -246,7 +294,7 @@ def main(pprmeta, finder, sorter, assembly, outdir, prefix=False):
         sorter_hc,
         sorter_lc,
         sorter_prophages,
-    ) = merge_annotations(pprmeta, finder, sorter, assembly)
+    ) = merge_annotations(pprmeta, finder, sorter, sorter2, assembly)
 
     at_least_one = False
     name_prefix = ""
@@ -336,6 +384,14 @@ if __name__ == "__main__":
         required=False,
     )
     parser.add_argument(
+        "-z",
+        "--vs2files",
+        dest="sorter2",
+        nargs="+",
+        help='VirSorter2 .tsv files (i.e. final-viral-{boundary,score}.tsv, final-viral-combined.fa)' " VirSorter2 output",
+        required=False,
+    )
+    parser.add_argument(
         "-p",
         "--pmout",
         dest="pprmeta",
@@ -357,13 +413,22 @@ if __name__ == "__main__":
         " _viral prediction files should be stored (default: cwd)",
         default=".",
     )
+    parser.add_argument(
+        "-y",
+        "--vs_cutoff",
+        dest="vs_cutoff",
+        help="Cutoff to categorize sequences identified by VirSorter2 to high or low confidence (default: 0.9).",
+        default="0.9",
+    )
     args = parser.parse_args()
 
     main(
         args.pprmeta,
         args.finder,
         args.sorter,
+        args.sorter2,
         args.assembly,
         args.outdir,
+        args.vs_cutoff,
         prefix=args.prefix,
     )

--- a/bin/parse_viral_pred.py
+++ b/bin/parse_viral_pred.py
@@ -188,10 +188,10 @@ def parse_virus_sorter(sorter_files):
 
 def parse_virus_sorter2(sorter_files):
     """Extract high, low and prophages confidence Records from virus sorter results.
-    High confidence are contigs in the categories 1 and 2
-    Low confidence are contigs in the category 3
-    Putative prophages are in categories 4 and 5
-    (which correspond to VirSorter confidence categories 1 and 2)
+    High confidence are contigs with confidence score >= confidence cutoff (0.9 per default).
+    Low confidence are contigs with confidence score < confidence cutoff and > 0.5.
+    Putative prophages are contigs with partial viral sequences. According to the VirSorter2 author
+    partial viral sequences can only occur as prophages, full viral sequences can occur due to prophages or other origins though.
     """
     high_confidence = dict()
     low_confidence = dict()

--- a/bin/parse_viral_pred.py
+++ b/bin/parse_viral_pred.py
@@ -200,7 +200,8 @@ def parse_virus_sorter2(sorter_files):
     if not sorter_files:
         print('WARNING: no result files from Virus Sorter 2 were found, skipping now.')
     else:
-        boundary_df = pd.read_csv([filename for filename in sorter_files if 'boundary' in filename][0], sep='\t', index_col = 'seqname_new')
+if ["final-viral-boundary.tsv", "final-viral-score.tsv", "final-viral-combined.fa"] not in sorter_files:
+    print('ERROR: The result files of Virus Sorter 3 are incomplete. The code expects the files final-viral-{boundary,score}.tsv and final-viral-combined.fa.', file=sys.stderr)
         score_df = pd.read_csv([filename for filename in sorter_files if 'score' in filename][0], sep='\t', index_col = 'seqname')
         meta = score_df.merge(boundary_df, left_index=True, right_index=True, how='left', suffixes = ('_score', '_boundary'))
 

--- a/bin/parse_viral_pred.py
+++ b/bin/parse_viral_pred.py
@@ -225,9 +225,6 @@ if ["final-viral-boundary.tsv", "final-viral-score.tsv", "final-viral-combined.f
             else:
                 low_confidence[record.id] = Record(record, "low_confidence", circular)
 
-
-
-
     print(f"Virus Sorter found {len(high_confidence)} high confidence contigs.")
     print(f"Virus Sorter found {len(low_confidence)} low confidence contigs.")
     print(f"Virus Sorter found {len(prophages)} putative prophages contigs.")

--- a/bin/parse_viral_pred.py
+++ b/bin/parse_viral_pred.py
@@ -274,7 +274,7 @@ def merge_annotations(pprmeta, finder, sorter, sorter2, assembly):
             lc_predictions_contigs.append(sorter_lc.get(seq_record.id).get_seq_record())
         elif seq_record.id in pprmeta_lc and seq_record.id in finder_lowestc:
             lc_predictions_contigs.append(seq_record)
-
+    
     return (
         hc_predictions_contigs,
         lc_predictions_contigs,
@@ -310,6 +310,9 @@ def main(pprmeta, finder, sorter, sorter2, assembly, outdir, vs_cutoff, prefix=F
             "fasta",
         )
         at_least_one = True
+    else:
+        print('No high confidence viral contigs found, skipping output file.')
+
     if len(lc_contigs):
         SeqIO.write(
             lc_contigs,
@@ -317,11 +320,17 @@ def main(pprmeta, finder, sorter, sorter2, assembly, outdir, vs_cutoff, prefix=F
             "fasta",
         )
         at_least_one = True
+    else:
+        print('No low confidence viral contigs found, skipping output file.')
+
     if len(prophage_contigs):
         SeqIO.write(
             prophage_contigs, outdir / Path(name_prefix + "prophages.fna"), "fasta"
         )
         at_least_one = True
+    else:
+        print('No prophage contigs found, skipping output file.')
+
 
     # VirSorter provides some metadata on each annotation
     # - is circular

--- a/bin/parse_viral_pred.py
+++ b/bin/parse_viral_pred.py
@@ -427,7 +427,8 @@ if __name__ == "__main__":
         "--vs_cutoff",
         dest="vs_cutoff",
         help="Cutoff to categorize sequences identified by VirSorter2 to high or low confidence (default: 0.9).",
-        default="0.9",
+        default=0.9,
+        type=float
     )
     args = parser.parse_args()
 

--- a/bin/write_viral_gff.py
+++ b/bin/write_viral_gff.py
@@ -52,6 +52,10 @@ def aggregate_annotations(virify_annotation_files):
     cds_annotations = {}
 
     for virify_summary in virify_annotation_files:
+        
+        if 'taxonomy' in virify_summary:
+            continue
+
         with open(virify_summary, "r") as table_handle:
             csv_reader = csv.DictReader(table_handle, delimiter="\t")
             for row in csv_reader:

--- a/nextflow.config
+++ b/nextflow.config
@@ -17,6 +17,7 @@ params {
 
     // databases
     virsorter = false
+    virsorter2 = false
     virfinder = false
     viphog = false
     ncbi = false
@@ -41,6 +42,7 @@ params {
     prop = 0.1
     taxthres = 0.6
     factor = "$projectDir/references/viphogs_cds_per_taxon_cummulative.csv"
+    use_virsorter2 = false
 
     sankey = 25
     chunk = 10

--- a/nextflow/configs/container.config
+++ b/nextflow/configs/container.config
@@ -26,6 +26,7 @@ process {
 
     withLabel: blast {          container = 'quay.io/microbiome-informatics/blast:2.9.0' } 
     withLabel: virsorter {      container = 'quay.io/microbiome-informatics/virsorter:1.0.6_edfeb8c5e72' }
+    withLabel: virsorter2 {     container = 'docker://jiarong/virsorter:2.2.3' }
     withLabel: mashmap {        container = 'quay.io/microbiome-informatics/mashmap:2.0' }
 
     withLabel: kaiju {          container = 'quay.io/biocontainers/kaiju:1.7.2--hdbcaa40_0' }

--- a/nextflow/configs/node.config
+++ b/nextflow/configs/node.config
@@ -25,7 +25,7 @@ process {
     withLabel: spades {         cpus = 12;           memory = '40.0 GB' } 
     withLabel: sankey {         cpus = 1;            memory = '2.0 GB' } 
     withLabel: virsorter {      cpus = 12;           memory = '12.0 GB' }
-    withLabel: virsorter2 {      cpus = 12;           memory = '12.0 GB' }
+    withLabel: virsorter2 {     cpus = 12;           memory = '12.0 GB' }
     withLabel: virfinder {      cpus = 1;            memory = '12.0 GB' }
     withLabel: mashmap {        cpus = 4;            memory = '4.0 GB' }          
 }

--- a/nextflow/configs/node.config
+++ b/nextflow/configs/node.config
@@ -25,6 +25,7 @@ process {
     withLabel: spades {         cpus = 12;           memory = '40.0 GB' } 
     withLabel: sankey {         cpus = 1;            memory = '2.0 GB' } 
     withLabel: virsorter {      cpus = 12;           memory = '12.0 GB' }
+    withLabel: virsorter2 {      cpus = 12;           memory = '12.0 GB' }
     withLabel: virfinder {      cpus = 1;            memory = '12.0 GB' }
     withLabel: mashmap {        cpus = 4;            memory = '4.0 GB' }          
 }

--- a/nextflow/modules/parse.nf
+++ b/nextflow/modules/parse.nf
@@ -11,7 +11,7 @@ process parse {
       contig_number.toInteger() > 0 
 
     output:
-      tuple val(name), file("*.fna"), file('virsorter_metadata.tsv'), file("${name}_virus_predictions.log"), optional: false
+      tuple val(name), file("*.fna"), file('virsorter_metadata.tsv'), file("${name}_virus_predictions.log"), optional: true
     
     script:
     if (params.use_virsorter2)

--- a/nextflow/modules/parse.nf
+++ b/nextflow/modules/parse.nf
@@ -11,7 +11,7 @@ process parse {
       contig_number.toInteger() > 0 
 
     output:
-      tuple val(name), file("*.fna"), file('virsorter_metadata.tsv'), file("${name}_virus_predictions.log"), optional: true
+      tuple val(name), file("*.fna"), file('virsorter_metadata.tsv'), file("${name}_virus_predictions.log"), optional: false
     
     script:
     if (params.use_virsorter2)
@@ -29,7 +29,7 @@ process parse {
 /*
   usage: parse_viral_pred.py [-h] -a ASSEMB -f FINDER -s SORTER [-o OUTDIR]
 
-  description: script generates three output_files: High_confidence.fasta, Low_confidence.fasta, Prophages.fasta
+  description: script generates three output_files: High_confidence.fna, Low_confidence.fna, Prophages.fna
 
   optional arguments:
   -h, --help            show this help message and exit
@@ -45,4 +45,6 @@ process parse {
   -o OUTDIR, --outdir OUTDIR
                         Absolute or relative path of directory where output
                         viral prediction files should be stored (default: cwd)
+
+NOTE: only outputs .fna files if some low confidence or high confidence viral seqs were identified, otherwise outputs nothing.
 */

--- a/nextflow/modules/parse.nf
+++ b/nextflow/modules/parse.nf
@@ -14,6 +14,12 @@ process parse {
       tuple val(name), file("*.fna"), file('virsorter_metadata.tsv'), file("${name}_virus_predictions.log"), optional: true
     
     script:
+    if (params.use_virsorter2)
+        """
+    touch virsorter_metadata.tsv
+    parse_viral_pred.py -a ${fasta} -f ${virfinder} -p ${pprmeta} -z ${virsorter} &> ${name}_virus_predictions.log
+    """
+    else
     """
     touch virsorter_metadata.tsv
     parse_viral_pred.py -a ${fasta} -f ${virfinder} -p ${pprmeta} -s ${virsorter}/Predicted_viral_sequences/*.fasta &> ${name}_virus_predictions.log

--- a/nextflow/modules/rename.nf
+++ b/nextflow/modules/rename.nf
@@ -1,6 +1,7 @@
 process rename {
       publishDir "${params.output}/${name}/", mode: 'copy', pattern: "${name}_renamed.fasta"
       label 'python3'
+      tag "$name"
 
     input:
       tuple val(name), file(fasta) 

--- a/nextflow/modules/virsorter2.nf
+++ b/nextflow/modules/virsorter2.nf
@@ -13,7 +13,6 @@ process virsorter2 {
     
     script:
       """
-      #virsorter config --init-source --db-dir=${params.databases}/virsorter2/virsorter2-data
       virsorter run -w virsorter2 -i ${fasta}  -j ${task.cpus} all
       """
 }

--- a/nextflow/modules/virsorter2.nf
+++ b/nextflow/modules/virsorter2.nf
@@ -1,0 +1,19 @@
+process virsorter2 {
+      publishDir "${params.output}/${name}/${params.virusdir}/", mode: 'copy', pattern: "virsorter2/*"
+      label 'virsorter2'
+
+    input:
+      tuple val(name), file(fasta), val(contig_number) 
+
+    when: 
+      contig_number.toInteger() > 0 
+
+    output:
+      tuple val(name), file("virsorter2/*")
+    
+    script:
+      """
+      #virsorter config --init-source --db-dir=${params.databases}/virsorter2/virsorter2-data
+      virsorter run -w virsorter2 -i ${fasta}  -j ${task.cpus} all
+      """
+}

--- a/nextflow/modules/virsorter2.nf
+++ b/nextflow/modules/virsorter2.nf
@@ -1,5 +1,5 @@
 process virsorter2 {
-      publishDir "${params.output}/${name}/${params.virusdir}/", mode: 'copy', pattern: "virsorter2/*"
+      publishDir "${params.output}/${name}/${params.virusdir}/", mode: 'copy', pattern: "virsorter2/*.{tsv,fasta}"
       label 'virsorter2'
 
     input:
@@ -9,7 +9,7 @@ process virsorter2 {
       contig_number.toInteger() > 0 
 
     output:
-      tuple val(name), file("virsorter2/*")
+      tuple val(name), file("virsorter2/*.{tsv,fa}")
     
     script:
       """

--- a/nextflow/modules/virsorter2GetDB.nf
+++ b/nextflow/modules/virsorter2GetDB.nf
@@ -1,0 +1,24 @@
+process virsorter2GetDB {
+  label 'virsorter2'    
+  if (params.cloudProcess) { 
+    publishDir "${params.databases}/virsorter2/", mode: 'copy', pattern: "virsorter2-data" 
+  }
+  else { 
+    storeDir "${params.databases}/virsorter2/" 
+  }  
+
+  output:
+    path("virsorter2-data", type: 'dir')
+    
+  script:
+    """
+    # just in case there is a failed attemp before; 
+    #   remove the whole diretory specified by -d
+    rm -rf virsorter2-data
+    # run setup
+    #virsorter setup -d virsorter2-data -j ${task.cpus}
+    wget https://osf.io/v46sc/download
+    mkdir virsorter2-data
+    tar -xzf db.tgz -C voirsorter2-data
+    """
+}

--- a/nextflow/modules/virsorter2GetDB.nf
+++ b/nextflow/modules/virsorter2GetDB.nf
@@ -19,6 +19,6 @@ process virsorter2GetDB {
     #virsorter setup -d virsorter2-data -j ${task.cpus}
     wget https://osf.io/v46sc/download
     mkdir virsorter2-data
-    tar -xzf db.tgz -C voirsorter2-data
+    tar -xzf db.tgz -C virsorter2-data
     """
 }

--- a/nextflow/modules/virsorter2GetDB.nf
+++ b/nextflow/modules/virsorter2GetDB.nf
@@ -13,10 +13,10 @@ process virsorter2GetDB {
   script:
     """
     # just in case there is a failed attemp before; 
-    #   remove the whole diretory specified by -d
+    # remove the whole diretory specified by -d
     rm -rf virsorter2-data
-    # run setup
-    #virsorter setup -d virsorter2-data -j ${task.cpus}
+    
+    # download virsorter2 database and extract
     wget https://osf.io/v46sc/download
     mkdir virsorter2-data
     tar -xzf db.tgz -C virsorter2-data

--- a/nextflow/modules/write_gff.nf
+++ b/nextflow/modules/write_gff.nf
@@ -1,14 +1,14 @@
 process write_gff {
     publishDir "${params.output}/${name}/${params.finaldir}/gff", mode: 'copy' , pattern: "*.gff"
 
-    errorStrategy 'ignore'
+    //errorStrategy 'ignore'
     label 'python3'
 
     input:
        tuple val(name), file(fasta)
-       path(viphos_annotations)
-       path(taxonomies)
-       path(quality_summaries)
+       path 'high_confidence_viral_contigs_prodigal_annotation*.tsv'
+       path 'high_confidence_viral_contigs_prodigal_annotation_taxonomy*.tsv'
+       path 'prophages_quality_summary*.tsv'
 
     output:
        file("${name}_virify.gff")
@@ -16,9 +16,9 @@ process write_gff {
     script:
     """
     write_viral_gff.py \
-    -v ${viphos_annotations.join(' ')} \
-    -c ${quality_summaries.join(' ')} \
-    -t ${taxonomies.join(' ')} \
+    -v high_confidence_viral_contigs_prodigal_annotation* \
+    -c prophages_quality_summary* \
+    -t high_confidence_viral_contigs_prodigal_annotation_taxonomy* \
     -s ${name} \
     -a ${fasta}
 

--- a/virify.nf
+++ b/virify.nf
@@ -427,10 +427,9 @@ workflow detect {
 
         // parsing predictions
         parse(length_filtered_ch.join(virfinder.out).join(virsorter_out).join(pprmeta.out))
-        parse.out.view{ it -> "$it" }
 
     emit:
-        parse.out.join(renamed_ch).view().transpose().map{name, fasta, vs_meta, log, renamed_fasta, map -> tuple (name, fasta, map)}
+        parse.out.join(renamed_ch).transpose().map{name, fasta, vs_meta, log, renamed_fasta, map -> tuple (name, fasta, map)}
 }
 
 

--- a/virify.nf
+++ b/virify.nf
@@ -504,9 +504,9 @@ workflow annotate {
         def k = 1 
 
         // enumerate collected files to prevent file collision
-        viphos_annotations = annotation.out.map { _, __, annotations -> tuple(annotations, i++) }.collect(){it -> it[0]} //{ annotations, count -> "$annotations".replace('.', '_' + count + '.') }
-        taxonomy_annotations = assign.out.map { _, __, taxonomy -> tuple(taxonomy, j++) }.collect(){it -> it[0]} //{ taxonomy, count -> "$taxonomy".replace('.', '_' + count + '.') }
-        checkv_results = checkV.out.map { _, __, quality_summary, ___ -> tuple(quality_summary, k++) }.collect(){it -> it[0]} //{ quality_summary, count -> "$quality_summary".replace('.', '_' + count + '.') }
+        viphos_annotations = annotation.out.map { _, __, annotations -> tuple(annotations, i++) }.collect(){it -> it[0]}
+        taxonomy_annotations = assign.out.map { _, __, taxonomy -> tuple(taxonomy, j++) }.collect(){it -> it[0]}
+        checkv_results = checkV.out.map { _, __, quality_summary, ___ -> tuple(quality_summary, k++) }.collect(){it -> it[0]}
 
         write_gff(
           // when using --list with multiple samples and the first assembly is bad by chance this generates one bad GFF file right?

--- a/virify.nf
+++ b/virify.nf
@@ -427,6 +427,7 @@ workflow detect {
 
         // parsing predictions
         parse(length_filtered_ch.join(virfinder.out).join(virsorter_out).join(pprmeta.out))
+        parse.out.view{ it -> "$it" }
 
     emit:
         parse.out.join(renamed_ch).view().transpose().map{name, fasta, vs_meta, log, renamed_fasta, map -> tuple (name, fasta, map)}
@@ -647,7 +648,7 @@ workflow {
           annotate(
             fasta_input_ch,
             postprocess(
-              preprocess.out.map{name, renamed_fasta, map, filtered_fasta, contig_number -> tuple(name, filtered_fasta, map)}.view()
+              preprocess.out.map{name, renamed_fasta, map, filtered_fasta, contig_number -> tuple(name, filtered_fasta, map)}
             ),
             viphog_db, ncbi_db, rvdb_db, pvogs_db, vogdb_db, vpf_db, imgvr_db, additional_model_data, checkv_db, factor_file
           )

--- a/virify.nf
+++ b/virify.nf
@@ -429,7 +429,7 @@ workflow detect {
         parse(length_filtered_ch.join(virfinder.out).join(virsorter_out).join(pprmeta.out))
 
     emit:
-        parse.out.join(renamed_ch).transpose().map{name, fasta, vs_meta, log, renamed_fasta, map -> tuple (name, fasta, map)}
+        parse.out.join(renamed_ch).view().transpose().map{name, fasta, vs_meta, log, renamed_fasta, map -> tuple (name, fasta, map)}
 }
 
 
@@ -647,7 +647,7 @@ workflow {
           annotate(
             fasta_input_ch,
             postprocess(
-              preprocess.out.map{name, renamed_fasta, map, filtered_fasta, contig_number -> tuple(name, filtered_fasta, map)}
+              preprocess.out.map{name, renamed_fasta, map, filtered_fasta, contig_number -> tuple(name, filtered_fasta, map)}.view()
             ),
             viphog_db, ncbi_db, rvdb_db, pvogs_db, vogdb_db, vpf_db, imgvr_db, additional_model_data, checkv_db, factor_file
           )

--- a/virify.nf
+++ b/virify.nf
@@ -499,11 +499,17 @@ workflow annotate {
           checkv_db
         )
 
-        viphos_annotations = annotation.out.map { _, __, annotations -> annotations }.collect()
-        taxonomy_annotations = assign.out.map { _, __, taxonomy -> taxonomy }.collect()
-        checkv_results = checkV.out.map { _, __, quality_summary, ___ -> quality_summary }.collect()
+        def i = 1 
+        def j = 1 
+        def k = 1 
+
+        // enumerate collected files to prevent file collision
+        viphos_annotations = annotation.out.map { _, __, annotations -> tuple(annotations, i++) }.collect(){it -> it[0]} //{ annotations, count -> "$annotations".replace('.', '_' + count + '.') }
+        taxonomy_annotations = assign.out.map { _, __, taxonomy -> tuple(taxonomy, j++) }.collect(){it -> it[0]} //{ taxonomy, count -> "$taxonomy".replace('.', '_' + count + '.') }
+        checkv_results = checkV.out.map { _, __, quality_summary, ___ -> tuple(quality_summary, k++) }.collect(){it -> it[0]} //{ quality_summary, count -> "$quality_summary".replace('.', '_' + count + '.') }
 
         write_gff(
+          // when using --list with multiple samples and the first assembly is bad by chance this generates one bad GFF file right?
           contigs.first(),
           viphos_annotations,
           taxonomy_annotations,


### PR DESCRIPTION
Added [VirSorter2](https://github.com/jiarong/VirSorter2) as a new process that can be used instead of `VirSorter` using the new flag `--use_virsort2`, adapted the downstream processes (the `parse` process and GFF generation script) to work with the different results of `VirSorter2`. E.g.: `VirSorter2` reports a confidence score (0-1) for every viral hit in the input data instead of a category.

Also had to add some changes to the GFF generation process because I always ran into file collision issues when more than one of the input samples reported significant viral sequences, since the `VirSort` and  `VirFinder` reports have the same file name for every sample. Might also be solved by running the GFF script for every sample containing viral seqs instead of once for all samples but I already asked about this in #127, maybe I'm missing something here!