### PR TITLE
Add chunking of input fasta for VirFinder and PPRmeta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.2] - [2026-06-09]
+
+### Added
+
+- Performance improvements: chunking of input fasta for VirFinder and PPRMeta to use parallelisation ([#176](https://github.com/EBI-Metagenomics/emg-viral-pipeline/pull/176))
+- Optimisation of SPLIT_PROTEINS module ([#171](https://github.com/EBI-Metagenomics/emg-viral-pipeline/pull/171))
+
+### Fixed
+
+- Set circularity of prophages detected by VirSorter2 to `linear` ([#176](https://github.com/EBI-Metagenomics/emg-viral-pipeline/pull/176))
+
 ## [3.3.1] - [2026-04-09]
 
 ### Fixed

--- a/bin/parse_viral_pred.py
+++ b/bin/parse_viral_pred.py
@@ -284,6 +284,11 @@ def parse_virus_sorter2(sorter_files, vs_cutoff):
             
             if "partial" in record.id:
                 record.id = clean_name
+                # In VirSorter2 records inherit "circular" label from the contig, which is incorrect for partial sequences 
+                # as they are extracted from the contig and might not be circular themselves.
+                # https://github.com/jiarong/VirSorter2/issues/251
+                # We rewrite "circular" to linear for partial sequences to avoid misinterpretation of the results.
+                circular = False
                 # add the prophage position within the contig
                 prophages.setdefault(clean_name, []).append(
                     Record(record, "prophage", circular, prange)

--- a/modules.json
+++ b/modules.json
@@ -10,6 +10,11 @@
                         "git_sha": "eeda4136c096688d04cc40bb3c70d948213ed641",
                         "installed_by": ["modules"]
                     },
+                    "csvtk/concat": {
+                        "branch": "master",
+                        "git_sha": "2f74af306499775ab48db1ed4077d2fa5aecf9c4",
+                        "installed_by": ["modules"]
+                    },
                     "fastp": {
                         "branch": "master",
                         "git_sha": "2c70c1c1951aaf884d2e8d8d9c871db79f7b35aa",

--- a/modules/local/pprmeta/main.nf
+++ b/modules/local/pprmeta/main.nf
@@ -8,7 +8,7 @@ process PPRMETA {
   path pprmeta_git
 
   output:
-  tuple val(meta), path("${meta.id}_pprmeta.csv")
+  tuple val(meta), path("${meta.id}.${fasta.baseName}_pprmeta.csv"), emit: result_csv
 
   when:
   contig_number.toInteger() > 0
@@ -19,7 +19,7 @@ process PPRMETA {
   mkdir -p \$(pwd)/mcr_cache_root
 
   [ -d "pprmeta" ] && cp pprmeta/* .
-  ./PPR_Meta ${fasta} ${meta.id}_pprmeta.csv
+  ./PPR_Meta ${fasta} ${meta.id}.${fasta.baseName}_pprmeta.csv
   """
 }
 

--- a/modules/local/split_proteins/main.nf
+++ b/modules/local/split_proteins/main.nf
@@ -3,8 +3,8 @@ process SPLIT_PROTEINS {
     label 'process_single'
     
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-                'https://depot.galaxyproject.org/singularity/biopython:1.86' :
-                'quay.io/biocontainers/biopython:1.86' }"
+                'https://depot.galaxyproject.org/singularity/biopython:1.84' :
+                'quay.io/biocontainers/biopython:1.84' }"
 
     input:
     tuple val(meta), val(confidence_set_name), path(fasta), path(proteins)

--- a/modules/local/split_proteins/main.nf
+++ b/modules/local/split_proteins/main.nf
@@ -3,8 +3,8 @@ process SPLIT_PROTEINS {
     label 'process_single'
     
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-                'https://depot.galaxyproject.org/singularity/biopython:1.84' :
-                'quay.io/biocontainers/biopython:1.84' }"
+                'oras://community.wave.seqera.io/library/pip_biopython:746a711789280f4a' :
+                'community.wave.seqera.io/library/pip_biopython:702fef869ad99456' }"
 
     input:
     tuple val(meta), val(confidence_set_name), path(fasta), path(proteins)

--- a/modules/local/virfinder/main.nf
+++ b/modules/local/virfinder/main.nf
@@ -11,7 +11,7 @@ process VIRFINDER {
   path model
 
   output:
-  tuple val(meta), path("${meta.id}.txt")
+  tuple val(meta), path("${meta.id}.${fasta.baseName}.txt"), emit: result_tsv
 
   when:
   contig_number.toInteger() > 0
@@ -19,6 +19,6 @@ process VIRFINDER {
   script:
   """
   run_virfinder.Rscript ${model} ${fasta} .
-  awk '{print \$1"\\t"\$2"\\t"\$3"\\t"\$4}' ${meta.id}*.tsv > ${meta.id}.txt
+  awk '{print \$1"\\t"\$2"\\t"\$3"\\t"\$4}' ${meta.id}*.tsv > ${meta.id}.${fasta.baseName}.txt
   """
 }

--- a/modules/nf-core/csvtk/concat/environment.yml
+++ b/modules/nf-core/csvtk/concat/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - conda-forge::csvtk=0.37.0

--- a/modules/nf-core/csvtk/concat/main.nf
+++ b/modules/nf-core/csvtk/concat/main.nf
@@ -1,0 +1,45 @@
+process CSVTK_CONCAT {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/91/917edb71b915f07fa2838c20e3c731181d3d315cbf8a9bfead41412d2b4ae062/data' :
+        'community.wave.seqera.io/library/csvtk:0.37.0--113625988dd3285d' }"
+
+    input:
+    tuple val(meta), path(csv, name: 'inputs/csv*/*')
+    val in_format
+    val out_format
+
+    output:
+    tuple val(meta), path("${prefix}.${out_extension}"), emit: csv
+    tuple val("${task.process}"), val('csvtk'), eval("csvtk version | sed -e 's/csvtk v//g'"), emit: versions_csvtk, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
+    def delimiter = in_format == "tsv" ? "\t" : (in_format == "csv" ? "," : in_format)
+    def out_delimiter = out_format == "tsv" ? "\t" : (out_format == "csv" ? "," : out_format)
+    out_extension = out_format == "tsv" ? 'tsv' : 'csv'
+    """
+    csvtk \\
+        concat \\
+        $args \\
+        --num-cpus $task.cpus \\
+        --delimiter "${delimiter}" \\
+        --out-delimiter "${out_delimiter}" \\
+        --out-file ${prefix}.${out_extension} \\
+        $csv
+    """
+
+    stub:
+    prefix = task.ext.prefix ?: "${meta.id}"
+    out_extension = out_format == "tsv" ? 'tsv' : 'csv'
+    """
+    touch ${prefix}.${out_extension}
+    """
+}

--- a/modules/nf-core/csvtk/concat/meta.yml
+++ b/modules/nf-core/csvtk/concat/meta.yml
@@ -1,0 +1,75 @@
+name: csvtk_concat
+description: Concatenate two or more CSV (or TSV) tables into a single table
+keywords:
+  - concatenate
+  - tsv
+  - csv
+tools:
+  - csvtk:
+      description: A cross-platform, efficient, practical CSV/TSV toolkit
+      homepage: http://bioinf.shenwei.me/csvtk
+      documentation: http://bioinf.shenwei.me/csvtk
+      tool_dev_url: https://github.com/shenwei356/csvtk
+      licence:
+        - "MIT"
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - csv:
+        type: file
+        description: CSV/TSV formatted files
+        pattern: "*.{csv,tsv}"
+        ontologies:
+          - edam: http://edamontology.org/format_3752 # CSV
+          - edam: http://edamontology.org/format_3475 # TSV
+  - in_format:
+      type: string
+      description: Input format (csv, tab, or a delimiting character)
+      pattern: "*"
+  - out_format:
+      type: string
+      description: Output format (csv, tab, or a delimiting character)
+      pattern: "*"
+output:
+  csv:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - ${prefix}.${out_extension}:
+          type: file
+          description: Concatenated CSV/TSV file
+          pattern: "*.{csv,tsv}"
+          ontologies:
+            - edam: http://edamontology.org/format_3752 # CSV
+            - edam: http://edamontology.org/format_3475 # TSV
+  versions_csvtk:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - csvtk:
+          type: string
+          description: The name of the tool
+      - csvtk version | sed -e 's/csvtk v//g':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - csvtk:
+          type: string
+          description: The name of the tool
+      - csvtk version | sed -e 's/csvtk v//g':
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@rpetit3"
+maintainers:
+  - "@rpetit3"

--- a/modules/nf-core/csvtk/concat/tests/main.nf.test
+++ b/modules/nf-core/csvtk/concat/tests/main.nf.test
@@ -1,0 +1,72 @@
+// nf-core modules test csvtk/concat
+nextflow_process {
+
+    name "Test Process CSVTK_CONCAT"
+    script "../main.nf"
+    process "CSVTK_CONCAT"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "csvtk"
+    tag "csvtk/concat"
+
+    test("tsv - concat - csv") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    [
+                        file("https://github.com/nf-core/test-datasets/raw/bacass/bacass_hybrid.csv", checkIfExists: true),
+                        file("https://github.com/nf-core/test-datasets/raw/bacass/bacass_long.csv", checkIfExists: true),
+                        file("https://github.com/nf-core/test-datasets/raw/bacass/bacass_short.csv", checkIfExists: true),
+                        file("https://github.com/nf-core/test-datasets/raw/bacass/bacass_short.csv", checkIfExists: true)
+                    ]
+                ]
+                input[1] = "tsv"
+                input[2] = "csv"
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+    test("tsv - concat - csv - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    [
+                        file("https://github.com/nf-core/test-datasets/raw/bacass/bacass_hybrid.csv", checkIfExists: true),
+                        file("https://github.com/nf-core/test-datasets/raw/bacass/bacass_long.csv", checkIfExists: true),
+                        file("https://github.com/nf-core/test-datasets/raw/bacass/bacass_short.csv", checkIfExists: true)
+                    ]
+                ]
+                input[1] = "tsv"
+                input[2] = "csv"
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/csvtk/concat/tests/main.nf.test.snap
+++ b/modules/nf-core/csvtk/concat/tests/main.nf.test.snap
@@ -1,0 +1,54 @@
+{
+    "tsv - concat - csv - stub": {
+        "content": [
+            {
+                "csv": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_csvtk": [
+                    [
+                        "CSVTK_CONCAT",
+                        "csvtk",
+                        "0.37.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-30T14:56:30.305631",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "26.04.0"
+        }
+    },
+    "tsv - concat - csv": {
+        "content": [
+            {
+                "csv": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.csv:md5,bb0ed52999b6b24297bcefb3c29f0a5c"
+                    ]
+                ],
+                "versions_csvtk": [
+                    [
+                        "CSVTK_CONCAT",
+                        "csvtk",
+                        "0.37.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-30T14:56:25.267323",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "26.04.0"
+        }
+    }
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@ manifest {
     name            = "VIRify"
     description     = """VIRify is a pipeline for the detection, annotation, and taxonomic classification of viral contigs in metagenomic and metatranscriptomic assemblies."""
     defaultBranch   = 'master'
-    version         = '3.3.1'
+    version         = '3.3.2'
 }
 
 params {

--- a/subworkflows/local/detect.nf
+++ b/subworkflows/local/detect.nf
@@ -11,6 +11,10 @@ include { CONCATENATE_FILES as CONCATENATE_FILES_SCORE               } from '../
 include { CONCATENATE_FILES as CONCATENATE_FILES_BOUNDARY            } from '../../modules/local/utils'
 include { CONCATENATE_FILES as CONCATENATE_FILES_FA                  } from '../../modules/local/utils'
 
+include { CSVTK_CONCAT as CSVTK_CONCAT_VIRFINDER                     } from '../../modules/nf-core/csvtk/concat'
+include { CSVTK_CONCAT as CSVTK_CONCAT_PPRMETA                       } from '../../modules/nf-core/csvtk/concat'
+
+
 workflow DETECT {
   take:
   renamed_assembly_and_contigs_count
@@ -19,6 +23,13 @@ workflow DETECT {
   pprmeta_git
 
   main:
+  // chunk fasta by 500Mb
+  chunked_ch = renamed_assembly_and_contigs_count.flatMap { meta, fasta, contigs_count ->
+     def chunks = fasta.splitFasta(file: true, size: 500.MB)
+     chunks.collect { chunk ->
+        return tuple(meta, chunk, contigs_count)
+     }
+  }
 
   // virus detection --> VirSorter/VirSorter2, VirFinder and PPR-Meta
 
@@ -32,13 +43,6 @@ workflow DETECT {
   }
   else {
 
-    // chunk fasta by 500Mb
-    chunked_ch = renamed_assembly_and_contigs_count.flatMap { meta, fasta, contigs_count ->
-      def chunks = fasta.splitFasta(file: true, size: 500.MB)
-      chunks.collect { chunk ->
-        return tuple(meta, chunk, contigs_count)
-      }
-    }
     VIRSORTER2(chunked_ch, virsorter_db)
 
     CONCATENATE_FILES_SCORE(
@@ -67,12 +71,26 @@ workflow DETECT {
       }
   }
 
-  VIRFINDER(renamed_assembly_and_contigs_count, virfinder_db)
+  VIRFINDER(chunked_ch, virfinder_db)
 
-  PPRMETA(renamed_assembly_and_contigs_count, pprmeta_git)
+  CSVTK_CONCAT_VIRFINDER (
+     VIRFINDER.out.result_tsv.groupTuple(),
+     'tsv',
+     'tsv'
+  )
+  virfinder_output = CSVTK_CONCAT_VIRFINDER.out.csv
+
+  PPRMETA(chunked_ch, pprmeta_git)
+
+  CSVTK_CONCAT_PPRMETA (
+     PPRMETA.out.result_csv.groupTuple(),
+     'csv',
+     'csv'
+  )
+  pprmeta_output = CSVTK_CONCAT_PPRMETA.out.csv
 
   // parsing predictions
-  PARSE(renamed_assembly_and_contigs_count.join(VIRFINDER.out).join(virsorter_output).join(PPRMETA.out))
+  PARSE(renamed_assembly_and_contigs_count.join(virfinder_output).join(virsorter_output).join(pprmeta_output))
 
   emit:
   detect_output = PARSE.out.map { meta, fasta, _vs_meta, _log -> tuple(meta, fasta) }


### PR DESCRIPTION
I transfered Kate's changes from #172 for chunking to include them to a small release that we can use in production (3.3.2). 

- Kate did chunking for VirFinder, I added one for PPRmeta
- I also had to redefine circularity to `False` in the `bin/parse_viral_pred.py` to fix this bug from VirSorter2 https://github.com/jiarong/VirSorter2/issues/251
- Update containers in SPLIT_PROTEINS because current singularity container is not accessible