### PR TITLE
Don't rename the taxonomy results -- also remove failOnError on publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ __pycache__/
 *.simg
 .DS_Store
 .claude/
+.serena/

--- a/configs/modules.config
+++ b/configs/modules.config
@@ -14,7 +14,6 @@ process {
             [
                 path: { "${params.output}/${meta.id}/${params.finaldir}/annotation/hmmer" },
                 mode: params.publish_dir_mode,
-                failOnError: false,
                 pattern: "*_annotation.tsv"
             ]
         ]
@@ -26,8 +25,8 @@ process {
                 path: { "${params.output}/${meta.id}/${params.taxdir}" },
                 enabled: params.publish_all,
                 mode: params.publish_dir_mode,
-                failOnError: false,
-                pattern: "*_taxonomy.tsv"
+                pattern: "*_taxonomy.tsv",
+                saveAs: { "${set_name}_annotation_taxonomy.tsv" },
             ],
         ]
     }
@@ -37,7 +36,6 @@ process {
             [
                 path: { "${params.output}/${meta.id}/${params.finaldir}/balloon" },
                 mode: params.publish_dir_mode,
-                failOnError: false,
                 pattern: "*.{pdf,svg}"
             ]
         ]
@@ -49,13 +47,11 @@ process {
                 path: { "${params.output}/${meta.id}/${params.blastdir}" },
                 enabled: params.publish_all,
                 mode: params.publish_dir_mode,
-                failOnError: false,
                 pattern: "*.blast"
             ],
             [
                 path: { "${params.output}/${meta.id}/${params.finaldir}/blast" },
                 mode: params.publish_dir_mode,
-                failOnError: false,
                 pattern: "*.filtered.blast"
             ],
         ]
@@ -67,13 +63,11 @@ process {
                 path: { "${params.output}/${meta.id}/${params.blastdir}" },
                 enabled: params.publish_all,
                 mode: params.publish_dir_mode,
-                failOnError: false,
                 pattern: "*.meta"
             ],
             [
                 path: { "${params.output}/${meta.id}/${params.finaldir}/blast" },
                 mode: params.publish_dir_mode,
-                failOnError: false,
                 pattern: "*.meta"
             ],
         ]
@@ -140,7 +134,6 @@ process {
                 path: { "${params.output}/${meta.id}/${params.plotdir}/krona" },
                 enabled: params.publish_all,
                 mode: params.publish_dir_mode,
-                failOnError: false,
                 pattern: "*counts.tsv",
             ],
         ]
@@ -152,21 +145,18 @@ process {
                 path: { "${params.output}/${meta.id}/${params.plotdir}/sankey" },
                 enabled: params.publish_all,
                 mode: params.publish_dir_mode,
-                failOnError: false,
                 pattern: "*.sankey.tsv"
             ],
             [
                 path: { "${params.output}/${meta.id}/${params.plotdir}/sankey" },
                 enabled: params.publish_all,
                 mode: params.publish_dir_mode,
-                failOnError: false,
                 pattern: "*.sankey.filtered-${params.sankey}.json"
             ],
             [
                 path: { "${params.output}/${meta.id}/${params.plotdir}/sankey" },
                 enabled: params.publish_all,
                 mode: params.publish_dir_mode,
-                failOnError: false,
                 pattern: "*.sankey.filtered.tsv"
             ]
         ]
@@ -177,7 +167,6 @@ process {
             [
                 path: { "${params.output}/${meta.id}/${params.finaldir}/chromomap" },
                 mode: params.publish_dir_mode,
-                failOnError: false,
                 pattern: "*.html"
             ]
         ]
@@ -188,7 +177,6 @@ process {
             [
                 path: { "${params.output}/${meta.id}/${params.hmmerdir}" },
                 mode: params.publish_dir_mode,
-                failOnError: false,
                 pattern: "*_modified.tsv"
             ]
         ]
@@ -200,14 +188,12 @@ process {
                 path: { "${params.output}/${meta.id}/${params.hmmerdir}/${db.baseName}" },
                 enabled: params.publish_all,
                 mode: params.publish_dir_mode,
-                failOnError: false,
                 pattern: "*_hmm*.tbl"
             ],
             [
                 path: { "${params.output}/${meta.id}/${params.hmmerdir}/${db.baseName}" },
                 enabled: params.publish_all,
                 mode: params.publish_dir_mode,
-                failOnError: false,
                 pattern: "*_cutga.tbl"
             ]
         ]
@@ -219,7 +205,6 @@ process {
             [
                 path: { "${params.output}/${meta.id}/${params.finaldir}/krona" },
                 mode: params.publish_dir_mode,
-                failOnError: false,
                 pattern: "*.krona.html"
             ],
         ]
@@ -230,7 +215,6 @@ process {
             [
                 path: { "${params.output}/${meta.id}/${params.finaldir}/mashmap" },
                 mode: params.publish_dir_mode,
-                failOnError: false,
                 pattern: "*.tsv"
             ]
         ]
@@ -241,7 +225,6 @@ process {
             [
                 path: { "${params.output}/${meta.id}/${params.finaldir}/multiqc" },
                 mode: params.publish_dir_mode,
-                failOnError: false,
                 pattern: "*_multiqc_report.html"
             ]
         ]
@@ -253,14 +236,12 @@ process {
                 path: { "${params.output}/${meta.id}/${params.virusdir}/virsorter2" },
                 enabled: params.publish_all,
                 mode: params.publish_dir_mode,
-                failOnError: false,
                 pattern: "virsorter_metadata.tsv"
             ],
             [
                 path: { "${params.output}/${meta.id}/${params.virusdir}" },
                 enabled: params.publish_all,
                 mode: params.publish_dir_mode,
-                failOnError: false,
                 pattern: "*_virus_predictions.stats"
             ]
         ]
@@ -271,7 +252,6 @@ process {
             [
                 path: { "${params.output}/${meta.id}/${params.finaldir}/annotation/plot_contig_map" },
                 mode: params.publish_dir_mode,
-                failOnError: false,
                 pattern: "*_mapping_results"
             ],
         ]
@@ -283,7 +263,6 @@ process {
                 path: { "${params.output}/${meta.id}/${params.virusdir}/pprmeta" },
                 enabled: params.publish_all,
                 mode: params.publish_dir_mode,
-                failOnError: false,
                 pattern: "*_pprmeta.csv"
             ]
         ]
@@ -296,7 +275,6 @@ process {
                 path: { "${params.output}/${meta.id}/${params.proteindir}" },
                 enabled: params.publish_all,
                 mode: params.publish_dir_mode,
-                failOnError: false,
                 pattern: "*.???.gz"
             ],
         ]
@@ -308,7 +286,6 @@ process {
                 path: { "${params.output}/${meta.id}/${params.hmmerdir}/ratio_evalue_tables" },
                 enabled: params.publish_all,
                 mode: params.publish_dir_mode,
-                failOnError: false,
                 pattern: "*_modified_informative.tsv"
             ]
         ]
@@ -319,7 +296,6 @@ process {
             [
                 path: { "${params.output}/${meta.id}/${params.finaldir}/contigs/" },
                 mode: params.publish_dir_mode,
-                failOnError: false,
                 pattern: "*_map.tsv"
             ]
         ]
@@ -330,7 +306,6 @@ process {
             [
                 path: { "${params.output}/${meta.id}/${params.finaldir}/contigs/" },
                 mode: params.publish_dir_mode,
-                failOnError: false,
                 pattern: "*_original.fasta"
             ]
         ]
@@ -341,7 +316,6 @@ process {
             [
                 path: { "${params.output}/${meta.id}/${params.finaldir}/sankey" },
                 mode: params.publish_dir_mode,
-                failOnError: false,
                 pattern: "*.sankey.html"
             ]
         ]
@@ -382,8 +356,6 @@ process {
             path: { "${params.output}/${meta.id}/${params.finaldir}/gff" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
-            // The GFF may not be generated... (I'm carrying this over as it was done like that in the past.. we need to review)
-            failOnError: false,
         ]
     }
 
@@ -395,8 +367,6 @@ process {
             path: { "${params.output}/${meta.id}/${params.finaldir}/gff" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
-            // Tthe GFF may not be generated... (I'm carrying this over as it was done like that in the past.. we need to review)
-            failOnError: false,
         ]
     }
 }

--- a/docs/output.md
+++ b/docs/output.md
@@ -107,9 +107,9 @@ In order to have expanded output with more files use `--publish_all` option in p
     │       ├── prophages.sankey.filtered-25.json
     │       └── prophages.sankey.tsv
     ├── 06-taxonomy
-    │   ├── high_confidence_viral_contigs_prodigal_annotation_taxonomy.tsv
-    │   ├── low_confidence_viral_contigs_prodigal_annotation_taxonomy.tsv
-    │   └── prophages_prodigal_annotation_taxonomy.tsv
+    │   ├── high_confidence_viral_contigs_annotation_taxonomy.tsv
+    │   ├── low_confidence_viral_contigs_annotation_taxonomy.tsv
+    │   └── prophages_annotation_taxonomy.tsv
     ├── 07-checkv
     │   ├── high_confidence_viral_contigs_quality_summary.tsv
     │   ├── low_confidence_viral_contigs_quality_summary.tsv


### PR DESCRIPTION
The taxonomy file results carried the _split_ in the name. This was introduced in the SPLIT_PROTEINS code recently. I've changed back the names of the files, but in the modules.config / publishDir.

I've removed the failOnError: false -> this could lead to runs that generate no results because a configuration error for example. I'm not sure what was the rationale, but if Nextfow can't copy the outputs it should fail.

I've added the serena tool folder to the ignore dir.